### PR TITLE
Added Kafka as Transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,29 @@ The leaf hub spec sync component of [Hub-of-Hubs](https://github.com/open-cluste
     $ export IMAGE=$REGISTRY/$(basename $(pwd)):latest
     ```
 
-1.  Set the `SYNC_SERVICE_PORT` environment variable to hold the ESS port as was setup in the leaf hub.
+1. Set the `TRANSPORT_TYPE` environment variable to "kafka" or "syncservice" to set which transport to use.
     ```
-    $ export SYNC_SERVICE_PORT=...
+    $ export TRANSPORT_TYPE=...
     ```
+1. If you chose Kafka for transport, set the following environment variables:
+
+    1. Set the `LH_ID` environment variable to hold the leaf hub unique id to be used as consumer group name.
+    ```
+    $ export LH_ID=...
+    ``` 
+   
+    2. If you use secured (SSL/TLS) client authorization, set `KAFKA_SSL_CA` environment variable to hold the
+       certificate (PEM format) encoded in base64.
+    ```
+    $ export KAFKA_SSL_CA=$(cat PATH_TO_CA | base64 -w 0)
+    ```
+
+1. Otherwise, if you chose Sync-Service as transport, set the following:
+
+    1. Set the `SYNC_SERVICE_PORT` environment variable to hold the ESS port as was setup in the leaf hub.
+        ```
+        $ export SYNC_SERVICE_PORT=...
+        ```
     
 1.  Run the following command to deploy the `leaf-hub-spec-sync` to your leaf hub cluster:  
     ```

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -30,5 +30,9 @@ RUN  /usr/local/scripts/user_setup
 RUN microdnf update && \
     microdnf clean all
 
+# allow user to fully control the bin directory (for transport certificates) -- for now
+RUN chown ${USER_UID}:0 /usr/local/bin
+RUN chmod 0775 /usr/local/bin
+
 USER ${USER_UID}
 ENTRYPOINT ["/usr/local/bin/manager"]

--- a/deploy/leaf-hub-spec-sync.yaml.template
+++ b/deploy/leaf-hub-spec-sync.yaml.template
@@ -99,6 +99,18 @@ spec:
                 fieldRef:
                  apiVersion: v1
                  fieldPath: metadata.namespace
+            - name: LH_ID
+              value: "$LH_ID"
+            - name: TRANSPORT_TYPE
+              value: "$TRANSPORT_TYPE"
+            - name: KAFKA_CONSUMER_ID
+              value: "$LH_ID"
+            - name: KAFKA_CONSUMER_HOSTS
+              value: "kafka-brokers-cluster-kafka-tls-bootstrap-kafka.apps.veisenbe-hoh2.dev10.red-chesterfield.com:443"
+            - name: KAFKA_CONSUMER_TOPIC
+              value: "spec"
+            - name: KAFKA_SSL_CA
+              value: "$KAFKA_SSL_CA"
             - name: SYNC_SERVICE_PROTOCOL
               value: "http"
             - name: SYNC_SERVICE_HOST

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,11 @@ module github.com/open-cluster-management/leaf-hub-spec-sync
 go 1.16
 
 require (
+	github.com/confluentinc/confluent-kafka-go v1.7.0
 	github.com/go-logr/logr v0.2.1
 	github.com/go-logr/zapr v0.2.0 // indirect
 	github.com/open-cluster-management/hub-of-hubs-data-types v0.1.0
+	github.com/open-cluster-management/hub-of-hubs-kafka-transport v0.0.0-20211017102605-842ae5d1c6ed
 	github.com/open-horizon/edge-sync-service-client v0.0.0-20190711093406-dc3a19905da2
 	github.com/open-horizon/edge-utilities v0.0.0-20190711093331-0908b45a7152 // indirect
 	github.com/operator-framework/operator-sdk v0.19.4

--- a/go.sum
+++ b/go.sum
@@ -161,6 +161,8 @@ github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMe
 github.com/cockroachdb/cockroach-go v0.0.0-20181001143604-e0a95dfd547c/go.mod h1:XGLbWH/ujMcbPbhZq52Nv6UrCghb1yGn//133kEsvDk=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
+github.com/confluentinc/confluent-kafka-go v1.7.0 h1:tXh3LWb2Ne0WiU3ng4h5qiGA9XV61rz46w60O+cq8bM=
+github.com/confluentinc/confluent-kafka-go v1.7.0/go.mod h1:u2zNLny2xq+5rWeTQjFHbDzzNuba4P1vo31r9r4uAdg=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
 github.com/containerd/console v0.0.0-20180822173158-c12b1e7919c1/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
 github.com/containerd/containerd v1.2.7/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
@@ -746,6 +748,8 @@ github.com/open-cluster-management/hub-of-hubs-data-types v0.0.0-20210801071204-
 github.com/open-cluster-management/hub-of-hubs-data-types v0.0.0-20210801071204-a16c44e7ec2b/go.mod h1:OOI0mxL5BOSq0TN6dVBfHiA6PUeapn+sMBXm9fLNaw8=
 github.com/open-cluster-management/hub-of-hubs-data-types v0.1.0 h1:w7DbcYX27W6qCnumAj0rQbvsLVwFY0ggy6ZXpbqPsus=
 github.com/open-cluster-management/hub-of-hubs-data-types v0.1.0/go.mod h1:OOI0mxL5BOSq0TN6dVBfHiA6PUeapn+sMBXm9fLNaw8=
+github.com/open-cluster-management/hub-of-hubs-kafka-transport v0.0.0-20211017102605-842ae5d1c6ed h1:b+0/8daIPw9NhlqH3tCxg2d1hVR54THfff3qlbIcwuA=
+github.com/open-cluster-management/hub-of-hubs-kafka-transport v0.0.0-20211017102605-842ae5d1c6ed/go.mod h1:Fhdc1zx1GwFuDn5p+KvWZ7fvhSvLet2Fr4cYdA3RUyI=
 github.com/open-horizon/edge-sync-service-client v0.0.0-20190711093406-dc3a19905da2 h1:ZmX/tuCgFVbe07pqObNWf14cAYpHN8gVRSkWnbtSUW4=
 github.com/open-horizon/edge-sync-service-client v0.0.0-20190711093406-dc3a19905da2/go.mod h1:rKW01VtqwtwaUQ+zkJ80X5EeGqsTblQE4J9HxPUtTAQ=
 github.com/open-horizon/edge-utilities v0.0.0-20190711093331-0908b45a7152 h1:YEvNOMo3ANOQ3AwsU0cCcBA4nKHDLUlyUCRWk5rBf68=

--- a/pkg/transport/kafka/kafka_consumer_client.go
+++ b/pkg/transport/kafka/kafka_consumer_client.go
@@ -1,0 +1,235 @@
+package kafka
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/confluentinc/confluent-kafka-go/kafka"
+	"github.com/go-logr/logr"
+	datatypes "github.com/open-cluster-management/hub-of-hubs-data-types"
+	kafkaClient "github.com/open-cluster-management/hub-of-hubs-kafka-transport/kafka-client/kafka-consumer"
+	"github.com/open-cluster-management/leaf-hub-spec-sync/pkg/bundle"
+	"github.com/open-cluster-management/leaf-hub-spec-sync/pkg/transport"
+)
+
+const (
+	commitRescheduleDelay = time.Second * 20
+	bufferedChannelSize   = 42
+)
+
+var errReceivedUnsupportedBundleType = errors.New("received unsupported message type")
+
+// NewConsumer creates a new instance of Consumer.
+func NewConsumer(log logr.Logger, bundleUpdatesChan chan *bundle.ObjectsBundle) (*Consumer, error) {
+	msgChan := make(chan *kafka.Message, bufferedChannelSize)
+
+	kafkaConsumer, err := kafkaClient.NewKafkaConsumer(msgChan, log)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create consumer: %w", err)
+	}
+
+	return &Consumer{
+		log:                             log,
+		kafkaConsumer:                   kafkaConsumer,
+		bundleCommitsChan:               make(chan interface{}, bufferedChannelSize),
+		bundleCommitsRetryChan:          make(chan interface{}, bufferedChannelSize),
+		msgChan:                         msgChan,
+		bundlesUpdatesChan:              bundleUpdatesChan,
+		partitionIDToCommittedOffsetMap: make(map[int32]kafka.Offset),
+		bundleToMsgMap:                  make(map[interface{}]*kafka.Message),
+		stopChan:                        make(chan struct{}),
+	}, nil
+}
+
+// Consumer abstracts hub-of-hubs-kafka-transport kafka-consumer's generic usage.
+type Consumer struct {
+	log                    logr.Logger
+	kafkaConsumer          *kafkaClient.KafkaConsumer
+	bundleCommitsChan      chan interface{}
+	bundleCommitsRetryChan chan interface{}
+	msgChan                chan *kafka.Message
+	bundlesUpdatesChan     chan *bundle.ObjectsBundle
+
+	partitionIDToCommittedOffsetMap map[int32]kafka.Offset
+	bundleToMsgMap                  map[interface{}]*kafka.Message
+
+	stopChan  chan struct{}
+	startOnce sync.Once
+	stopOnce  sync.Once
+}
+
+// Start function starts the consumer.
+func (c *Consumer) Start() error {
+	if err := c.kafkaConsumer.Subscribe(); err != nil {
+		return fmt.Errorf("failed to start consumer: %w", err)
+	}
+
+	c.startOnce.Do(func() {
+		go c.handleCommits()
+		go c.handleKafkaMessages()
+		go c.handleCommitRetries()
+	})
+
+	return nil
+}
+
+// Stop stops the consumer.
+func (c *Consumer) Stop() {
+	c.stopOnce.Do(func() {
+		close(c.stopChan)
+		close(c.msgChan)
+		close(c.bundleCommitsChan)
+		close(c.bundleCommitsRetryChan)
+		c.kafkaConsumer.Close()
+	})
+}
+
+// CommitAsync commits a transported message that was processed locally.
+func (c *Consumer) CommitAsync(bundle interface{}) {
+	c.bundleCommitsChan <- bundle
+}
+
+func (c *Consumer) handleKafkaMessages() {
+	for {
+		select {
+		case <-c.stopChan:
+			return
+
+		case msg := <-c.msgChan:
+			c.processMessage(msg)
+		}
+	}
+}
+
+func (c *Consumer) handleCommits() {
+	for {
+		select {
+		case <-c.stopChan:
+			return
+
+		case processedBundle := <-c.bundleCommitsChan:
+			c.commitOffset(processedBundle)
+		}
+	}
+}
+
+func (c *Consumer) handleCommitRetries() {
+	ticker := time.NewTicker(commitRescheduleDelay)
+
+	type bundleInfo struct {
+		bundle interface{}
+		offset kafka.Offset
+	}
+
+	partitionIDToHighestBundleMap := make(map[int32]bundleInfo)
+
+	for {
+		select {
+		case <-c.stopChan:
+			return
+
+		case <-ticker.C:
+			for partition, highestBundle := range partitionIDToHighestBundleMap {
+				go func() {
+					// TODO reschedule, should use exponential back off
+					c.bundleCommitsChan <- highestBundle.bundle
+				}()
+
+				delete(partitionIDToHighestBundleMap, partition)
+			}
+
+		case bundleToRetry := <-c.bundleCommitsRetryChan:
+			msg, exists := c.bundleToMsgMap[bundleToRetry]
+			if !exists {
+				continue
+			}
+
+			msgPartition := msg.TopicPartition.Partition
+			msgOffset := msg.TopicPartition.Offset
+
+			highestBundle, found := partitionIDToHighestBundleMap[msgPartition]
+			if found && highestBundle.offset > msgOffset {
+				c.log.Info("transport dropped low commit retry request",
+					"topic", *msg.TopicPartition.Topic,
+					"partition", msg.TopicPartition.Partition,
+					"offset", msgOffset)
+
+				continue
+			}
+
+			// update partition mapping
+			partitionIDToHighestBundleMap[msgPartition] = bundleInfo{
+				bundle: bundleToRetry,
+				offset: msgOffset,
+			}
+		}
+	}
+}
+
+func (c *Consumer) commitOffset(bundle interface{}) {
+	msg, exists := c.bundleToMsgMap[bundle]
+	if !exists {
+		return
+	}
+
+	msgOffset := msg.TopicPartition.Offset
+	msgPartition := msg.TopicPartition.Partition
+
+	if msgOffset > c.partitionIDToCommittedOffsetMap[msgPartition] {
+		if err := c.kafkaConsumer.Commit(msg); err != nil {
+			c.log.Error(err, "transport failed to commit message",
+				"topic", *msg.TopicPartition.Topic,
+				"partition", msg.TopicPartition.Partition,
+				"offset", msgOffset)
+
+			go func() {
+				c.bundleCommitsRetryChan <- bundle
+			}()
+
+			return
+		}
+
+		delete(c.bundleToMsgMap, bundle)
+		c.partitionIDToCommittedOffsetMap[msgPartition] = msgOffset
+		c.log.Info("transport committed message", "topic", *msg.TopicPartition.Topic,
+			"partition", msg.TopicPartition.Partition,
+			"offset", msgOffset)
+	} else {
+		// a more recent message was committed, drop current
+		delete(c.bundleToMsgMap, bundle)
+	}
+}
+
+func (c *Consumer) processMessage(msg *kafka.Message) {
+	transportMsg := &transport.Message{}
+
+	if err := json.Unmarshal(msg.Value, transportMsg); err != nil {
+		c.log.Error(err, "failed to parse transport message", "message key", string(msg.Key),
+			"topic", msg.TopicPartition.Topic, "partition", msg.TopicPartition.Partition,
+			"offset", msg.TopicPartition.Offset)
+
+		return
+	}
+
+	switch transportMsg.MsgType {
+	case datatypes.Config:
+		fallthrough // same behavior as SpecBundle
+	case datatypes.SpecBundle:
+		receivedBundle := &bundle.ObjectsBundle{}
+		c.bundleToMsgMap[receivedBundle] = msg
+
+		if err := json.Unmarshal(transportMsg.Payload, receivedBundle); err != nil {
+			c.log.Error(err, "failed to parse bundle", "object id", transportMsg.ID,
+				"message key", string(msg.Key))
+
+			return
+		}
+
+		c.bundlesUpdatesChan <- receivedBundle
+	default:
+		c.log.Error(errReceivedUnsupportedBundleType, "message type", transportMsg.MsgType)
+	}
+}

--- a/pkg/transport/sync-service/sync_service.go
+++ b/pkg/transport/sync-service/sync_service.go
@@ -96,11 +96,16 @@ func readEnvVars() (string, string, uint16, int, error) {
 	return protocol, host, uint16(port), pollingInterval, nil
 }
 
+// CommitAsync commits a transported message that was processed locally.
+func (s *SyncService) CommitAsync(_ interface{}) {}
+
 // Start function starts sync service.
-func (s *SyncService) Start() {
+func (s *SyncService) Start() error {
 	s.startOnce.Do(func() {
 		go s.handleBundles()
 	})
+
+	return nil
 }
 
 // Stop function stops sync service.

--- a/pkg/transport/transport.go
+++ b/pkg/transport/transport.go
@@ -1,4 +1,10 @@
 package transport
 
 // Transport is an interface for transport layer.
-type Transport interface{}
+type Transport interface {
+	CommitAsync(interface{})
+	// Start starts the transport.
+	Start() error
+	// Stop stops the transport.
+	Stop()
+}

--- a/pkg/transport/transport_message.go
+++ b/pkg/transport/transport_message.go
@@ -1,0 +1,9 @@
+package transport
+
+// Message abstracts a message object to be used by different transport components.
+type Message struct {
+	ID      string `json:"id"`
+	MsgType string `json:"msgType"`
+	Version string `json:"version"`
+	Payload []byte `json:"payload"`
+}


### PR DESCRIPTION
This update introduces Kafka as transport implementation where the spec bundles may be received through it or through the sync service (configurable).